### PR TITLE
Add publish test github action

### DIFF
--- a/.github/workflows/publish-and-test.yml
+++ b/.github/workflows/publish-and-test.yml
@@ -1,0 +1,17 @@
+name: Publish
+
+on:
+  pull_request: 
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.7
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4.0.0
+        with:
+          dotnet-version: 8.0.100
+      - name: Dotnet Publish
+        run: dotnet publish


### PR DESCRIPTION
Since I normally work in a .net8.0 environment, I can't check if the error occurs in other TargetFrameworks, so I run the dotnet publish command when the PR is generated to see if it works in other TargetFrameworks.