### PR TITLE
Set actual sha to PackageProjectUrl property

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -34,10 +34,12 @@ jobs:
 
           Remove-Item -Force -Recurse pack -ErrorAction SilentlyContinue  
 
+          $commitSHA = "$(git log -1 --pretty=%H)"
           .github/scripts/pack.ps1 `
             -OutputPath "pack" `
             -PullRequestNumber $matches[1] `
-            -KeyPath "$pwd/private.snk"
+            -KeyPath "$pwd/private.snk" `
+            -CommitSHA $commitSHA
           
           Get-ChildItem -Path pack -Filter "*.nupkg" | ForEach-Object {
             dotnet nuget push `

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,11 @@ Communication changes
 
 To be released.
 
-* Improve CI to make sure minimal checks are done before merge [[#26]]
+* Improve CI to make sure minimal checks are done before merge  [[#26]]
+* Set actual sha to PackageProjectUrl property  [[#27]]
 
-[26]: https://github.com/s2quake/communication/pull/26
+[#26]: https://github.com/s2quake/communication/pull/26
+[#27]: https://github.com/s2quake/communication/pull/27
 
 
 2.0.2


### PR DESCRIPTION
On the Nuget website for a specific version of this library, when a user clicks on 'source repository', I want the website to take them to the actual repository URL that was used to package this library.
I'm not sure if this pull request will work in practice, I'll find out once it's merged 😀